### PR TITLE
Add missing ggml-base library to the CUDA build to enable GPU

### DIFF
--- a/recipe/0001-ggml-cuda-depends-on-ggml-base.patch
+++ b/recipe/0001-ggml-cuda-depends-on-ggml-base.patch
@@ -1,0 +1,27 @@
+From ca81d095d32b9869ba52f0ab7a651405da7a1c31 Mon Sep 17 00:00:00 2001
+From: Jindrich Makovicka <jindrich.makovicka@qminers.com>
+Date: Wed, 30 Jul 2025 07:20:49 -0400
+Subject: [PATCH] ggml-cuda depends on ggml-base
+
+Change-Id: Ic03f24f94300f5a3803d5468277a0bee2d36f930
+---
+ CMakeLists.txt | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b3b5438a..2432837d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -78,7 +78,7 @@ if(CMAKE_CUDA_COMPILER)
+ 
+     find_package(CUDAToolkit)
+     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/ml/backend/ggml/ggml/src/ggml-cuda)
+-    install(TARGETS ggml-cuda
++    install(TARGETS ggml-cuda ggml-base
+         RUNTIME_DEPENDENCIES
+             DIRECTORIES ${CUDAToolkit_BIN_DIR} ${CUDAToolkit_LIBRARY_DIR}
+             PRE_INCLUDE_REGEXES cublas cublasLt cudart
+-- 
+2.49.0
+
+

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,9 +11,11 @@ package:
 source:
   url: https://github.com/ollama/ollama/archive/refs/tags/v${{ version }}.tar.gz
   sha256: 3ab00a02358696ce0c6ec97ca31037553c50ab6a6f57cc1825c713072540c6d3
+  patches:
+    - 0001-ggml-cuda-depends-on-ggml-base.patch
 
 build:
-  number: 2
+  number: 3
   string: ${{ string_prefix }}h${{ hash }}_${{ number }}
   variant:
     use_keys:


### PR DESCRIPTION
ggml-cuda library needs ggml-base to work. This patch makes the CUDA build actually use the GPU instead of CPU only.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
