### PR TITLE
Proper fix for the missing build number

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,6 +3,7 @@ context:
   cuda: ${{ "true" if cuda_compiler_version != "None" else "" }}
   cuda_build_string: cuda_${{ cuda_compiler_version | version_to_buildstring }}
   string_prefix: ${{ cuda_build_string if cuda else "cpu_" }}
+  build_number: 4
 
 package:
   name: ollama
@@ -15,8 +16,8 @@ source:
     - 0001-ggml-cuda-depends-on-ggml-base.patch
 
 build:
-  number: 3
-  string: ${{ string_prefix }}h${{ hash }}_${{ number }}
+  number: ${{ build_number }}
+  string: ${{ string_prefix }}h${{ hash }}_${{ build_number }}
   variant:
     use_keys:
       # use cuda from the variant config, e.g. to build multiple CUDA variants


### PR DESCRIPTION
Add build_number variable to context and use it where necessary.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
